### PR TITLE
Run vsgImGui consumer smoke test

### DIFF
--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -8,3 +8,6 @@ if errorlevel 1 exit 1
 
 cmake --build tests/build --parallel --config Release
 if errorlevel 1 exit 1
+
+ctest --test-dir tests/build --output-on-failure -C Release
+if errorlevel 1 exit 1

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -10,3 +10,4 @@ cmake tests \
     -DCMAKE_BUILD_TYPE=Release
 
 cmake --build tests/build --parallel
+ctest --test-dir tests/build --output-on-failure

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -10,4 +10,6 @@ cmake tests \
     -DCMAKE_BUILD_TYPE=Release
 
 cmake --build tests/build --parallel
+export LD_LIBRARY_PATH="${PREFIX}/lib:${LD_LIBRARY_PATH:-}"
+export DYLD_FALLBACK_LIBRARY_PATH="${PREFIX}/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
 ctest --test-dir tests/build --output-on-failure

--- a/recipe/tests/CMakeLists.txt
+++ b/recipe/tests/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.7)
 
 project(vsghelloworld)
 
+include(CTest)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -11,3 +13,7 @@ find_package(vsgImGui CONFIG REQUIRED)
 
 add_executable(vsghelloworld main.cpp)
 target_link_libraries(vsghelloworld PRIVATE vsgXchange::vsgXchange vsgImGui::vsgImGui)
+
+add_executable(vsgimgui_smoke smoke.cpp)
+target_link_libraries(vsgimgui_smoke PRIVATE vsgImGui::vsgImGui)
+add_test(NAME vsgimgui_smoke COMMAND vsgimgui_smoke)

--- a/recipe/tests/smoke.cpp
+++ b/recipe/tests/smoke.cpp
@@ -1,0 +1,20 @@
+#include <vsgImGui/SendEventsToImGui.h>
+#include <vsgImGui/imgui.h>
+#include <vsgImGui/implot.h>
+
+#include <imgui.h>
+#include <implot.h>
+
+int main()
+{
+    ImGui::CreateContext();
+    ImPlot::CreateContext();
+
+    auto handler = vsgImGui::SendEventsToImGui::create();
+    const bool ok = static_cast<bool>(handler);
+
+    ImPlot::DestroyContext();
+    ImGui::DestroyContext();
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
This is a test-only follow-up for stronger package-test coverage.

Changes:
- Keep the existing `find_package(vsgXchange CONFIG REQUIRED)` / `find_package(vsgImGui CONFIG REQUIRED)` consumer compile test.
- Add a headless `vsgimgui_smoke` executable that creates ImGui/ImPlot contexts and a `vsgImGui::SendEventsToImGui` handler.
- Register the smoke executable with CTest and run CTest from Unix and Windows package-test scripts.
- Export the prefix library path before Unix CTest so the just-built consumer can load shared libraries from the test environment.

Validation:
- `git diff --check upstream/main..HEAD`
- `conda-smithy recipe-lint --conda-forge recipe`

No build-number bump: package contents and runtime metadata are unchanged.
