### PR TITLE
Fix vsgImGui system ImGui texture ABI

### DIFF
--- a/recipe/patches/0004-Use-system-ImTextureID-ABI-when-requested.patch
+++ b/recipe/patches/0004-Use-system-ImTextureID-ABI-when-requested.patch
@@ -1,0 +1,89 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jeongseok Lee <jeongseok@meta.com>
+Date: Sat, 16 May 2026 07:30:00 -0700
+Subject: [PATCH] Use system ImTextureID ABI when requested
+
+---
+ include/vsgImGui/Export.h   |  8 ++++++--
+ src/CMakeLists.txt          |  8 ++++++++
+ src/vsgImGui/Texture.cpp    | 19 ++++++++++++++++++-
+ 3 files changed, 32 insertions(+), 3 deletions(-)
+
+diff --git a/include/vsgImGui/Export.h b/include/vsgImGui/Export.h
+index 95eb49c..948c192 100644
+--- a/include/vsgImGui/Export.h
++++ b/include/vsgImGui/Export.h
+@@ -34,11 +34,17 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ #    define VSGIMGUI_DECLSPEC
+ #endif
+ 
++#ifndef VSG_IMGUI_USE_SYSTEM_IMGUI
+ #define IMGUI_API VSGIMGUI_DECLSPEC
++#endif
++#ifndef VSG_IMGUI_USE_SYSTEM_IMPLOT
+ #define IMPLOT_API VSGIMGUI_DECLSPEC
++#endif
+ 
+ #include <vulkan/vulkan.h>
++#ifndef VSG_IMGUI_USE_SYSTEM_IMGUI
+ #define ImTextureID VkDescriptorSet
++#endif
+ 
+ #include <vsg/maths/vec2.h>
+ #include <vsg/maths/vec4.h>
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 97720b2..a73b780 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -87,6 +87,14 @@ set_property(TARGET vsgImGui PROPERTY CXX_STANDARD 17)
+ 
+ target_compile_definitions(vsgImGui PRIVATE ${EXTRA_DEFINES})
+ 
++if(VSG_IMGUI_USE_SYSTEM_IMGUI)
++    target_compile_definitions(vsgImGui PUBLIC VSG_IMGUI_USE_SYSTEM_IMGUI)
++endif()
++
++if(VSG_IMGUI_USE_SYSTEM_IMPLOT)
++    target_compile_definitions(vsgImGui PUBLIC VSG_IMGUI_USE_SYSTEM_IMPLOT)
++endif()
++
+ target_include_directories(vsgImGui PUBLIC
+     $<BUILD_INTERFACE:${VSGIMGUI_SOURCE_DIR}/include>
+     $<BUILD_INTERFACE:${VSGIMGUI_SOURCE_DIR}/include/vsgImGui>
+diff --git a/src/vsgImGui/Texture.cpp b/src/vsgImGui/Texture.cpp
+index 1619866..49fa04b 100644
+--- a/src/vsgImGui/Texture.cpp
++++ b/src/vsgImGui/Texture.cpp
+@@ -24,10 +24,25 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ 
+ #include <vsg/state/DescriptorImage.h>
+ 
++#include <cstdint>
++
+ using namespace vsgImGui;
+ 
+ namespace
+ {
++    ImTextureID descriptorSetToTextureID(VkDescriptorSet descriptorSet)
++    {
++#ifdef VSG_IMGUI_USE_SYSTEM_IMGUI
++#    if VK_USE_64_BIT_PTR_DEFINES == 1
++        return static_cast<ImTextureID>(reinterpret_cast<std::uintptr_t>(descriptorSet));
++#    else
++        return static_cast<ImTextureID>(descriptorSet);
++#    endif
++#else
++        return static_cast<ImTextureID>(descriptorSet);
++#endif
++    }
++
+     auto getDefaultSampler()
+     {
+         auto sampler = vsg::Sampler::create();
+@@ -75,5 +92,5 @@ void Texture::compile(vsg::Context& context)
+ 
+ ImTextureID Texture::id(uint32_t deviceID) const
+ {
+-    return descriptorSet ? static_cast<ImTextureID>(descriptorSet->vk(deviceID)) : ImTextureID{};
++    return descriptorSet ? descriptorSetToTextureID(descriptorSet->vk(deviceID)) : ImTextureID{};
+ }

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -12,9 +12,10 @@ source:
   patches:
     - patches/0001-Add-options-to-use-system-dependencies.patch
     - patches/0003-Find-imgui-and-implot-in-package-config-when-system-.patch
+    - patches/0004-Use-system-ImTextureID-ABI-when-requested.patch
 
 build:
-  number: 2
+  number: 3
   script:
     - if: win
       then: call "%RECIPE_DIR%\\build.bat"

--- a/recipe/tests/smoke.cpp
+++ b/recipe/tests/smoke.cpp
@@ -1,17 +1,28 @@
 #include <vsgImGui/SendEventsToImGui.h>
+#include <vsgImGui/Texture.h>
 #include <vsgImGui/imgui.h>
 #include <vsgImGui/implot.h>
 
 #include <imgui.h>
 #include <implot.h>
 
+#include <type_traits>
+
+namespace
+{
+using ImageFunction = void (*)(ImTextureID, const ImVec2&, const ImVec2&, const ImVec2&, const ImVec4&, const ImVec4&);
+ImageFunction volatile image_function = &ImGui::Image;
+} // namespace
+
 int main()
 {
+    static_assert(std::is_integral<ImTextureID>::value, "system imgui should provide the ImTextureID ABI");
+
     ImGui::CreateContext();
     ImPlot::CreateContext();
 
     auto handler = vsgImGui::SendEventsToImGui::create();
-    const bool ok = static_cast<bool>(handler);
+    const bool ok = static_cast<bool>(handler) && image_function != nullptr;
 
     ImPlot::DestroyContext();
     ImGui::DestroyContext();


### PR DESCRIPTION
Fixes #6 follow-up.

This keeps the feedstock on conda-forge system `imgui` and `implot`, but fixes the ABI mismatch reported in the issue:

- in system-ImGui mode, `vsgImGui/Export.h` no longer forces `ImTextureID` to `VkDescriptorSet`, so consumers compile against the same default `ImTextureID` ABI as the conda `imgui` package
- `vsgImGui::Texture::id()` still returns a Vulkan descriptor set as an ImGui texture ID by converting the `VkDescriptorSet` handle to the system `ImTextureID` representation
- the CMake target now propagates the system dependency mode to downstream consumers
- the package test now builds a CMake consumer and keeps a real reference to `ImGui::Image(ImTextureID, ...)`, so the reported undefined symbol is covered

Validation:

- `conda-smithy recipe-lint --conda-forge recipe`
- `pixi run build-linux_64_`
- inspected the Linux artifact: `libvsgImGui.so` links against system `libimgui.so` and `libimplot.so`, and no `libvsgImGui.a` is shipped